### PR TITLE
Fast scrolling bug + scroll events rather than reqAnimFrame

### DIFF
--- a/js/stroll.js
+++ b/js/stroll.js
@@ -199,7 +199,8 @@
 			scrollBottom = scrollTop + this.listHeight;
 
 		// Quit if nothing changed
-		if( scrollTop !== this.lastTop || force ) {
+		if( !this.lock && scrollTop !== this.lastTop || force ) {
+			this.lock = true;
 			this.lastTop = scrollTop;
 
 			// One loop to make our changes to the DOM
@@ -212,6 +213,7 @@
 					if( item._state !== STATE_PAST ) {
 						item._state = STATE_PAST;
 						item.classList.add( STATE_PAST );
+						item.classList.remove( STATE_FUTURE );
 					}
 				}
 				// Below list viewport
@@ -220,6 +222,7 @@
 					if( item._state !== STATE_FUTURE ) {
 						item._state = STATE_FUTURE;
 						item.classList.add( STATE_FUTURE );
+						item.classList.remove( STATE_PAST );
 					}
 				}
 				// Inside of list viewport
@@ -229,6 +232,8 @@
 					item._state = STATE_NULL;
 				}
 			}
+
+			this.lock = false;
 		}
 	}
 
@@ -447,7 +452,8 @@
 		}
 
 		// Only proceed if the scroll position has changed
-		if( scrollTop !== this.top.natural || force ) {
+		if( !this.lock && scrollTop !== this.top.natural || force ) {
+			this.lock = true;
 			this.top.natural = scrollTop;
 			this.top.value = scrollTop - this.touch.offset;
 
@@ -462,6 +468,7 @@
 					// Exclusion via string matching improves performance
 					if( this.velocity <= 0 && item._state !== STATE_PAST ) {
 						item.classList.add( STATE_PAST );
+						item.classList.remove( STATE_FUTURE );
 						item._state = STATE_PAST;
 					}
 				}
@@ -470,6 +477,7 @@
 					// Exclusion via string matching improves performance
 					if( this.velocity >= 0 && item._state !== STATE_FUTURE ) {
 						item.classList.add( STATE_FUTURE );
+						item.classList.remove( STATE_PAST );
 						item._state = STATE_FUTURE;
 					}
 				}
@@ -480,6 +488,8 @@
 					item._state = STATE_NULL;
 				}
 			}
+
+			this.lock = false;
 		}
 	};
 

--- a/js/stroll.js
+++ b/js/stroll.js
@@ -490,29 +490,30 @@
 	/**
 	 * Public API
 	 */
-	window.stroll = {
-		/**
-		 * Binds one or more lists for scroll effects.
-		 * 
-		 * @see #add()
-		 */
-		bind: function( target, options ) {
-			if( isCapable() ) {
+	window.stroll = isCapable()
+		? {
+			/**
+			 * Binds one or more lists for scroll effects.
+			 * 
+			 * @see #add()
+			 */
+			bind: function( target, options ) {
 				batch( target, add, options );
-			}
-		},
+			},
 
-		/**
-		 * Unbinds one or more lists from scroll effects.
-		 * 
-		 * @see #remove()
-		 */
-		unbind: function( target ) {
-			if( isCapable() ) {
+			/**
+			 * Unbinds one or more lists from scroll effects.
+			 * 
+			 * @see #remove()
+			 */
+			unbind: function( target ) {
 				batch( target, remove );
 			}
 		}
-	};
+		: {
+			bind: function() {},
+			unbind: function() {}
+		};
 
 	window.requestAnimFrame = (function(){
 		return  window.requestAnimationFrame       ||

--- a/js/stroll.js
+++ b/js/stroll.js
@@ -5,8 +5,7 @@
  * 
  * Copyright (C) 2012 Hakim El Hattab, http://hakim.se
  */
-(function(){
-
+(function( window, undefined ) {
 	"use strict";
 
 	var _slice = [].slice;
@@ -23,6 +22,17 @@
 	var	STATE_NULL		= null,
 		STATE_PAST		= 'past',
 		STATE_FUTURE	= 'future';
+
+	var	requestAnimationFrame = (function() {
+			return	window.requestAnimationFrame
+				||	window.webkitRequestAnimationFrame
+				||	window.mozRequestAnimationFrame
+				||	window.oRequestAnimationFrame
+				||	window.msRequestAnimationFrame
+				||	function( callback ) {
+						window.setTimeout( callback, 1000 / 60 );
+					};
+		})();
 
 	/**
 	 * Starts monitoring a list and applies classes to each of 
@@ -159,7 +169,7 @@
 
 	List.prototype.unInit = function() {
 		this.element.removeEventListener( 'scroll', this.scrollDelegate, false );
-		this.scrollDelegate = null;
+		this.scrollDelegate = undefined;
 	};
 
 	/** 
@@ -237,7 +247,6 @@
 	List.prototype.destroy = function() {
 		if ( this.syncTimeout ) {
 			window.clearTimeout( this.syncTimeout );
-			this.syncTimeout = null;
 		}
 
 		for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
@@ -258,231 +267,149 @@
 	 * to read the up-to-date scroll position.
 	 */
 	function TouchList( element, options ) {
-		List.apply( this, arguments );
-
-		this.element.style.overflow = 'hidden';
-
-		this.top = {
-			value: 0,
-			natural: 0
-		};
-
 		this.touch = {
+			max: 0,
 			value: 0,
 			offset: 0,
 			start: 0,
 			previous: 0,
 			lastMove: Date.now(),
-			accellerateTimeout: -1,
+			accellerateTimeout: null,
 			isAccellerating: false,
-			isActive: false
+			scrollTop: 0,
+			velocity: 0
 		};
+		this.touch.swipe = this.onSwipe.bind( this, this.touch );
 
-		this.velocity = 0;
+		List.apply( this, arguments );
+
+		this.element.style.overflow = 'hidden';
 	}
+
 	TouchList.prototype = new List();
+
 	TouchList.prototype.constructor = TouchList;
 
 	TouchList.prototype.init = function() {
-		this.touchStartDelegate = this.onTouchStart.bind( this );
-		this.touchMoveDelegate = this.onTouchMove.bind( this );
-		this.touchEndDelegate = this.onTouchEnd.bind( this );
+		this.touchStartDelegate = this.onTouchStart.bind( this, this.touch );
+		this.touchMoveDelegate = this.onTouchMove.bind( this, this.touch );
+		this.touchEndDelegate = this.onTouchEnd.bind( this, this.touch );
 		this.element.addEventListener( 'touchstart', this.touchStartDelegate, false );
 		this.element.addEventListener( 'touchmove', this.touchMoveDelegate, false );
 		this.element.addEventListener( 'touchend', this.touchEndDelegate, false );
+
+		List.prototype.init.call( this );
 	};
 
 	TouchList.prototype.unInit = function() {
 		this.element.removeEventListener( 'touchstart', this.touchStartDelegate, false );
 		this.element.removeEventListener( 'touchmove', this.touchMoveDelegate, false );
 		this.element.removeEventListener( 'touchend', this.touchEndDelegate, false );
-		this.touchStartDelegate = null;
-		this.touchMoveDelegate = null;
-		this.touchEndDelegate = null;
+		this.touchStartDelegate = undefined;
+		this.touchMoveDelegate = undefined;
+		this.touchEndDelegate = undefined;
 	};
 
-	/** 
-	 * Fetches the latest properties from the DOM to ensure that 
-	 * this list is in sync with its contents. This is typically 
-	 * only used once (per list) at initialization.
-	 */
 	TouchList.prototype.sync = function() {
-		this.items = _slice.apply( this.element.children );
+		List.prototype.sync.call( this );
 
-		this.listHeight = this.element.offsetHeight;
-
-		// One loop to get the properties we need from the DOM
-		for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
-			item = items[i];
-			item._offsetHeight = item.offsetHeight;
-			item._offsetTop = item.offsetTop;
-			item._offsetBottom = item._offsetTop + item._offsetHeight;
-			item._state = STATE_NULL;
-
-			// Animating opacity is a MAJOR performance hit on mobile so we can't allow it
-			item.style.opacity = 1;
-		}
-
-		this.top.natural = this.element.scrollTop;
-		this.top.value = this.top.natural;
-		this.top.max = item._offsetBottom - this.listHeight;
-
-		// Force an update
-		this.update( true );
+		this.touch.max = this.items[ this.items.length-1 ]._offsetBottom - this.listHeight;
 	};
 
-	TouchList.prototype.onTouchStart = function( event ) {
+	TouchList.prototype.onTouchStart = function( touch, event ) {
 		event.preventDefault();
 
 		if( event.touches.length === 1 ) {
-			this.touch.isActive = true;
-			this.touch.start = event.touches[0].clientY;
-			this.touch.previous = this.touch.start;
-			this.touch.value = this.touch.start;
-			this.touch.offset = 0;
+			touch.start		=
+			touch.previous	=
+			touch.value		= event.touches[0].clientY;
+			touch.offset	= 0;
+			touch.lastMove	= Date.now();
+			touch.scrollTop	= this.element.scrollTop;
 
-			if( this.velocity ) {
-				this.touch.isAccellerating = true;
-
-				var scope = this;
-
-				this.touch.accellerateTimeout = setTimeout( function() {
-					scope.touch.isAccellerating = false;
-					scope.velocity = 0;
+			if ( touch.velocity ) {
+				touch.isAccellerating = true;
+				touch.accellerateTimeout = window.setTimeout( function() {
+					touch.isAccellerating = false;
+					touch.velocity = 0;
 				}, 500 );
-			}
-			else {
-				this.velocity = 0;
+			} else {
+				touch.velocity = 0;
 			}
 		}
 	};
 
-	TouchList.prototype.onTouchMove = function( event ) {
+	TouchList.prototype.onTouchMove = function( touch, event ) {
 		if( event.touches.length === 1 ) {
-			var previous = this.touch.value;
+			var	previous	= touch.value,
+				lastMove	= touch.lastMove,
+				value		= event.touches[0].clientY,
+				now			= Date.now(),
+				isSameDir	=  value > previous && touch.velocity < 0
+							|| value < previous && touch.velocity > 0;
 
-			this.touch.value = event.touches[0].clientY;
-			this.touch.lastMove = Date.now();
-
-			var sameDirection = ( this.touch.value > this.touch.previous && this.velocity < 0 )
-								|| ( this.touch.value < this.touch.previous && this.velocity > 0 );
-
-			if( this.touch.isAccellerating && sameDirection ) {
-				clearInterval( this.touch.accellerateTimeout );
-
-				// Increase velocity significantly
-				this.velocity += ( this.touch.previous - this.touch.value ) / 10;
-			}
-			else {
-				this.velocity = 0;
-
-				this.touch.isAccellerating = false;
-				this.touch.offset = Math.round( this.touch.start - this.touch.value );
+			if( touch.isAccellerating && isSameDir ) {
+				window.clearTimeout( touch.accellerateTimeout );
+				touch.velocity += ( value - previous ) / ( now - lastMove );
+			} else {
+				touch.isAccellerating = false;
+				touch.velocity = 0;
 			}
 
-			this.touch.previous = previous;
+			touch.scrollTop	+= previous - value;
+			touch.offset	 = touch.start - value;
+			touch.previous	 = previous;
+			touch.value		 = value;
+			touch.lastMove	 = now;
+
+			// ScrollTo
+			this.element.scrollTop = Math.max( 0, Math.min( touch.max, touch.scrollTop ) );
 		}
 	};
 
-	TouchList.prototype.onTouchEnd = function( event ) {
-		var distanceMoved = this.touch.start - this.touch.value;
-
-		if( !this.touch.isAccellerating ) {
-			// Apply velocity based on the start position of the touch
-			this.velocity = ( this.touch.start - this.touch.value ) / 10;
-		}
+	TouchList.prototype.onTouchEnd = function( touch, event ) {
+		var	distance = Math.abs( touch.previous - touch.value ),
+			now = Date.now();
 
 		// Don't apply any velocity if the touch ended in a still state
-		if( Date.now() - this.touch.lastMove > 200 || Math.abs( this.touch.previous - this.touch.value ) < 5 ) {
-			this.velocity = 0;
+		if( now - touch.lastMove > 200 || distance < 5 ) {
+			touch.velocity = 0;
+		} else if( !touch.isAccellerating ) {
+			// Apply velocity based on the start position of the touch
+			touch.velocity = touch.offset / ( now - touch.lastMove );
 		}
 
-		this.top.value += this.touch.offset;
+		window.clearTimeout( touch.accellerateTimeout );
 
-		// Reset the variables used to determne swipe speed
-		this.touch.offset = 0;
-		this.touch.start = 0;
-		this.touch.value = 0;
-		this.touch.isActive = false;
-		this.touch.isAccellerating = false;
-
-		clearInterval( this.touch.accellerateTimeout );
+		// Do the scrolling
+		if ( touch.velocity !== 0 ) {
+			touch.swipe();
+		}
 
 		// If a swipe was captured, prevent event propagation
-		if( Math.abs( this.velocity ) > 4 || Math.abs( distanceMoved ) > 10 ) {
+		if( Math.abs( touch.velocity ) > 4 || distance > 10 ) {
 			event.preventDefault();
 		}
 	};
 
-	/** 
-	 * Apply past/future classes to list items outside of the viewport
-	 */
-	TouchList.prototype.update = function( force ) {
-		// Determine the desired scroll top position
-		var scrollTop = this.top.value + this.velocity + this.touch.offset;
-
-		// Only scroll the list if there's input
-		if( this.velocity || this.touch.offset ) {
-			// Scroll the DOM and add on the offset from touch
-			this.element.scrollTop = scrollTop;
-
-			// Keep the scroll value within bounds
-			scrollTop = Math.max( 0, Math.min( this.element.scrollTop, this.top.max ) );
-
-			// Cache the currently set scroll top and touch offset
-			this.top.value = scrollTop - this.touch.offset;
-		}
-
-		// If there is no active touch, decay velocity
-		if( !this.touch.isActive || this.touch.isAccellerating ) {
-			this.velocity *= 0.95;
-		}
+	TouchList.prototype.onSwipe = function( touch ) {
+		// Decay velocity (based on fps)
+		touch.velocity *= 0.95;
 
 		// Cut off early, the last fraction of velocity doesn't have 
 		// much impact on movement
-		if( Math.abs( this.velocity ) < 0.15 ) {
-			this.velocity = 0;
+		if( Math.abs( touch.velocity ) < 0.15 ) {
+			touch.velocity = 0;
 		}
 
-		// Only proceed if the scroll position has changed
-		if( !this.lock && scrollTop !== this.top.natural || force ) {
-			this.lock = true;
-			this.top.natural = scrollTop;
-			this.top.value = scrollTop - this.touch.offset;
+		// Apply velocity to the current position
+		touch.scrollTop			+= touch.velocity;
+		// and scroll (this will trigger the update method)
+		this.element.scrollTop	= Math.max( 0, Math.min( touch.max, touch.scrollTop ) );
 
-			var scrollBottom = scrollTop + this.listHeight;
-
-			// One loop to make our changes to the DOM
-			for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
-				item = items[i];
-
-				// Above list viewport
-				if( item._offsetBottom < scrollTop ) {
-					// Exclusion via string matching improves performance
-					if( this.velocity <= 0 && item._state !== STATE_PAST ) {
-						item.classList.add( STATE_PAST );
-						item.classList.remove( STATE_FUTURE );
-						item._state = STATE_PAST;
-					}
-				}
-				// Below list viewport
-				else if( item._offsetTop > scrollBottom ) {
-					// Exclusion via string matching improves performance
-					if( this.velocity >= 0 && item._state !== STATE_FUTURE ) {
-						item.classList.add( STATE_FUTURE );
-						item.classList.remove( STATE_PAST );
-						item._state = STATE_FUTURE;
-					}
-				}
-				// Inside of list viewport
-				else if( item._state ) {
-					if( item._state === STATE_PAST ) item.classList.remove( STATE_PAST );
-					if( item._state === STATE_FUTURE ) item.classList.remove( STATE_FUTURE );
-					item._state = STATE_NULL;
-				}
-			}
-
-			this.lock = false;
+		// loop onSwipe method until velocity hits 0
+		if ( touch.velocity !== 0 ) {
+			requestAnimationFrame( touch.swipe );
 		}
 	};
 
@@ -515,15 +442,4 @@
 			unbind: function() {}
 		};
 
-	window.requestAnimFrame = (function(){
-		return  window.requestAnimationFrame       ||
-				window.webkitRequestAnimationFrame ||
-				window.mozRequestAnimationFrame    ||
-				window.oRequestAnimationFrame      ||
-				window.msRequestAnimationFrame     ||
-				function( callback ){
-					window.setTimeout(callback, 1000 / 60);
-				};
-	})();
-
-})();
+})( window );

--- a/js/stroll.js
+++ b/js/stroll.js
@@ -18,6 +18,10 @@
 	// All of the lists that are currently bound
 	var lists = [];
 
+	var	STATE_NULL		= null,
+		STATE_PAST		= 'past',
+		STATE_FUTURE	= 'future';
+
 	// Set to true when there are lists to refresh
 	var active = false;
 
@@ -178,7 +182,7 @@
 			item._offsetHeight = item.offsetHeight;
 			item._offsetTop = item.offsetTop;
 			item._offsetBottom = item._offsetTop + item._offsetHeight;
-			item._state = '';
+			item._state = STATE_NULL;
 		}
 
 		// Force an update
@@ -203,24 +207,24 @@
 				// Above list viewport
 				if( item._offsetBottom < scrollTop ) {
 					// Exclusion via string matching improves performance
-					if( item._state !== 'past' ) {
-						item._state = 'past';
-						item.classList.add( 'past' );
+					if( item._state !== STATE_PAST ) {
+						item._state = STATE_PAST;
+						item.classList.add( STATE_PAST );
 					}
 				}
 				// Below list viewport
 				else if( item._offsetTop > scrollBottom ) {
 					// Exclusion via string matching improves performance
-					if( item._state !== 'future' ) {
-						item._state = 'future';
-						item.classList.add( 'future' );
+					if( item._state !== STATE_FUTURE ) {
+						item._state = STATE_FUTURE;
+						item.classList.add( STATE_FUTURE );
 					}
 				}
 				// Inside of list viewport
 				else if( item._state ) {
-					if( item._state === 'past' ) item.classList.remove( 'past' );
-					if( item._state === 'future' ) item.classList.remove( 'future' );
-					item._state = '';
+					if( item._state === STATE_PAST ) item.classList.remove( STATE_PAST );
+					if( item._state === STATE_FUTURE ) item.classList.remove( STATE_FUTURE );
+					item._state = STATE_NULL;
 				}
 			}
 		}
@@ -235,8 +239,8 @@
 		for( var j = 0, len = this.items.length; j < len; j++ ) {
 			var item = this.items[j];
 
-			item.classList.remove( 'past' );
-			item.classList.remove( 'future' );
+			item.classList.remove( STATE_PAST );
+			item.classList.remove( STATE_FUTURE );
 		}
 	}
 
@@ -289,7 +293,7 @@
 			item._offsetHeight = item.offsetHeight;
 			item._offsetTop = item.offsetTop;
 			item._offsetBottom = item._offsetTop + item._offsetHeight;
-			item._state = '';
+			item._state = STATE_NULL;
 
 			// Animating opacity is a MAJOR performance hit on mobile so we can't allow it
 			item.style.opacity = 1;
@@ -456,24 +460,24 @@
 				// Above list viewport
 				if( item._offsetBottom < scrollTop ) {
 					// Exclusion via string matching improves performance
-					if( this.velocity <= 0 && item._state !== 'past' ) {
-						item.classList.add( 'past' );
-						item._state = 'past';
+					if( this.velocity <= 0 && item._state !== STATE_PAST ) {
+						item.classList.add( STATE_PAST );
+						item._state = STATE_PAST;
 					}
 				}
 				// Below list viewport
 				else if( item._offsetTop > scrollBottom ) {
 					// Exclusion via string matching improves performance
-					if( this.velocity >= 0 && item._state !== 'future' ) {
-						item.classList.add( 'future' );
-						item._state = 'future';
+					if( this.velocity >= 0 && item._state !== STATE_FUTURE ) {
+						item.classList.add( STATE_FUTURE );
+						item._state = STATE_FUTURE;
 					}
 				}
 				// Inside of list viewport
 				else if( item._state ) {
-					if( item._state === 'past' ) item.classList.remove( 'past' );
-					if( item._state === 'future' ) item.classList.remove( 'future' );
-					item._state = '';
+					if( item._state === STATE_PAST ) item.classList.remove( STATE_PAST );
+					if( item._state === STATE_FUTURE ) item.classList.remove( STATE_FUTURE );
+					item._state = STATE_NULL;
 				}
 			}
 		}

--- a/js/stroll.js
+++ b/js/stroll.js
@@ -89,10 +89,10 @@
 	 * @param {HTMLElement} element 
 	 */
 	function remove( element ) {
-		for( var i = 0; i < lists.length; i++ ) {
-			var list = lists[i];
+		for( var list, i = 0, len = lists.length; i < len; i++ ) {
+			list = lists[i];
 
-			if( list.element == element ) {
+			if( list && list.element === element ) {
 				list.destroy();
 				lists.splice( i, 1 );
 				i--;
@@ -109,8 +109,10 @@
 	 * Checks if the specified element has already been bound.
 	 */
 	function contains( element ) {
-		for( var i = 0, len = lists.length; i < len; i++ ) {
-			if( lists[i].element == element ) {
+		for( var list, i = 0, len = lists.length; i < len; i++ ) {
+			list = lists[i];
+
+			if( list && list.element === element ) {
 				return true;
 			}
 		}
@@ -177,8 +179,8 @@
 		this.listHeight = this.element.offsetHeight;
 
 		// One loop to get the offsets from the DOM
-		for( var i = 0, len = this.items.length; i < len; i++ ) {
-			var item = this.items[i];
+		for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
+			item = items[i];
 			item._offsetHeight = item.offsetHeight;
 			item._offsetTop = item.offsetTop;
 			item._offsetBottom = item._offsetTop + item._offsetHeight;
@@ -201,8 +203,8 @@
 			this.lastTop = scrollTop;
 
 			// One loop to make our changes to the DOM
-			for( var i = 0, len = this.items.length; i < len; i++ ) {
-				var item = this.items[i];
+			for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
+				item = items[i];
 
 				// Above list viewport
 				if( item._offsetBottom < scrollTop ) {
@@ -236,8 +238,8 @@
 	List.prototype.destroy = function() {
 		clearInterval( this.syncInterval );
 
-		for( var j = 0, len = this.items.length; j < len; j++ ) {
-			var item = this.items[j];
+		for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
+			item = items[i];
 
 			item.classList.remove( STATE_PAST );
 			item.classList.remove( STATE_FUTURE );
@@ -285,11 +287,9 @@
 
 		this.listHeight = this.element.offsetHeight;
 
-		var item;
-
 		// One loop to get the properties we need from the DOM
-		for( var i = 0, len = this.items.length; i < len; i++ ) {
-			item = this.items[i];
+		for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
+			item = items[i];
 			item._offsetHeight = item.offsetHeight;
 			item._offsetTop = item.offsetTop;
 			item._offsetBottom = item._offsetTop + item._offsetHeight;
@@ -454,8 +454,8 @@
 			var scrollBottom = scrollTop + this.listHeight;
 			
 			// One loop to make our changes to the DOM
-			for( var i = 0, len = this.items.length; i < len; i++ ) {
-				var item = this.items[i];
+			for( var item, items = this.items, i = 0, len = items.length; i < len; i++ ) {
+				item = items[i];
 
 				// Above list viewport
 				if( item._offsetBottom < scrollTop ) {


### PR DESCRIPTION
Hello!
I really like your project, it has some pretty nice effects. Its just awesome!

While playing around at the demopage I noticed some issues with scrolling up and down very fast. In some cases a few items inside the viewport still animate or just disappear because they still have classnames applied.
So I had a look at the code and I also noticed that you are using requestAnimationFrame to change the classList on every child node. The problem here is that the update function will be called over and over again even though the user is not scrolling.

I fixed the fast-scrolling-bug by adding a locking variable to the update function and I also fixed some tiny performance issues here and there.
The big change I made was to use scroll events instead of using requestAnimationFrame so the update function will now only be called while the user is scrolling. Because of that I also had to change the TouchList and its swipe behavior. The swipe machanism still uses reqAnimFrame but only to reduce the velocity of the swipe...

Overall I've managed to storten the code (TouchList now uses List's sync() and update() method).


Please have a look at the changes and tell me what you think. Thanks!