### PR TITLE
Fix fast scroll bug

### DIFF
--- a/js/stroll.js
+++ b/js/stroll.js
@@ -206,6 +206,7 @@
 					if( item._state !== 'past' ) {
 						item._state = 'past';
 						item.classList.add( 'past' );
+						item.classList.remove( 'future' );
 					}
 				}
 				// Below list viewport
@@ -214,6 +215,7 @@
 					if( item._state !== 'future' ) {
 						item._state = 'future';
 						item.classList.add( 'future' );
+						item.classList.remove( 'past' );
 					}
 				}
 				// Inside of list viewport


### PR DESCRIPTION
The fast scroll action make that sometimes an element can have both past and future class.

Simply avoid it by removing the useless class systematically.
